### PR TITLE
feat: mobile responsive layout + UI polish + i18n fixes

### DIFF
--- a/frontend/src/components/Map/mapStyles.js
+++ b/frontend/src/components/Map/mapStyles.js
@@ -158,13 +158,18 @@ export const TRANSPORT_MODE_STYLES = {
   },
   train: {
     color: '#7C3AED',  // Violet
-    dasharray: [4, 2],
+    dasharray: null,   // Solid line for public transit
     icon: 'train',
   },
   bus: {
-    color: '#EA580C',  // Terracotta
-    dasharray: [3, 2],
+    color: '#7C3AED',  // Violet (public transit)
+    dasharray: null,   // Solid line for public transit
     icon: 'bus',
+  },
+  transit: {
+    color: '#7C3AED',  // Violet (public transit)
+    dasharray: null,   // Solid line for public transit
+    icon: 'train',
   },
   plane: {
     color: '#0284C7',  // Sky blue


### PR DESCRIPTION
## Summary
- **Mobile responsive layout**: Tab-based (List/Map) navigation for viewports < 768px with bottom tab bar and "..." more menu for Journal/Calendar/Vault access
- **i18n coverage**: Complete Spanish/English translation coverage, fix pluralization rules, add missing keys across 20+ components
- **Map UI cleanup**: Remove redundant controls, fix legend positioning, render public transit routes as solid purple lines
- **Itinerary footer fix**: Proper sticky positioning with route summary bar

## Changes (4 commits)
1. `fix: complete i18n coverage and fix pluralization across frontend` — 67 new/updated translation keys, fixed date-fns locale, pluralization
2. `fix: clean up map UI and improve itinerary footer` — removed duplicate map controls, fixed legend position, transit route colors, sticky footer
3. `feat: add responsive mobile layout with tab-based navigation` — new `useIsMobile` hook, `mobileActiveTab` context state, bottom tab bar, more menu dropdown, Mapbox-safe panel toggling with `visibility:hidden`
4. `fix: render public transit routes as solid purple lines` — train/bus/transit modes now use solid violet (#7C3AED) lines

## Test plan
- [ ] Verify mobile (< 768px): List tab shows full-width itinerary, Map tab shows full-screen map
- [ ] Verify tab switching preserves state (no re-renders or data loss)
- [ ] Verify "..." more menu opens Journal, Calendar, Vault as overlays
- [ ] Verify desktop (≥ 768px): split-panel layout unchanged, no bottom tab bar
- [ ] Verify train/bus segments render as solid purple lines on map
- [ ] Verify all UI text appears in Spanish when locale is `es`

🤖 Generated with [Claude Code](https://claude.com/claude-code)